### PR TITLE
fixed question delete issue

### DIFF
--- a/quiz/templates/quiz/partial_question_delete.html
+++ b/quiz/templates/quiz/partial_question_delete.html
@@ -1,4 +1,4 @@
-<form method="poat" action="{% url 'question-delete' form.instance.inquiz.pk form.instance.pk %}" class="js-question-delete-form">
+<form method="POST" action="{% url 'question-delete' quiz_id question.id %}" class="js-question-delete-form">
   {% csrf_token %}
   <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-label="Close">

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -116,11 +116,11 @@ def question_delete(request, quiz_id, pk):
         question.delete()
         data['form_is_valid'] = True  # This is just to play along with the existing code
         questions = Question.objects.all()
-        data['html_question_list'] = render_to_string('quiz/partial_question_delete.html', {
+        data['html_question_list'] = render_to_string('quiz/partial_question_list.html', {
             'questions': questions
         })
     else:
-        context = {'question': question}
+        context = { 'question': question, 'question_id': pk, 'quiz_id': quiz_id }
         data['html_form'] = render_to_string('quiz/partial_question_delete.html', 
             context,
             request=request,


### PR DESCRIPTION
1. The dialog wasn’t showing-up: In the question_delete function, the context was:

`	context = { 'question': question }
`

It couldn’t find the variables form.instance.inquiz.pk and form.instance.pk. I changed it to this:

`	context = { 'question': question, 'question_id': pk, 'quiz_id': quiz_id }
`

and the partial to this:

`	<form method="poat" action="{% url 'question-delete' quiz_id question.id %}" class="js-question-delete-form”>
`

2. The other issue is above ^^ “poat” should be POST. I also changed the delete POST destination to quiz/partial_question_delete.html. That way, it renders the rest of the list after delete. Note that for deleting the question, you don’t need the quizID; the questionID’s should be universally unique.